### PR TITLE
fix: prevent URI encoding

### DIFF
--- a/src/utils/rest.ts
+++ b/src/utils/rest.ts
@@ -31,7 +31,7 @@ async function emitRequest<TResponse extends any = {}>(url: string, init?: Reque
 function generateQuery<T extends Record<string, string | number | boolean> = {}>(url: string, params?: T) {
   let query = '?';
   if (params) {
-    for (const [key, value] of Object.entries(params)) query += `${key}=${encodeURIComponent(value)}&`;
+    for (const [key, value] of Object.entries(params)) query += `${key}=${value}&`;
     query = query.slice(0, -1); // Remove trailing "&"
   }
   return params ? `${url}${query}` : url;


### PR DESCRIPTION
### 📦 Pull Request

The API doesn't seem to decode query parameters on its end; that said, encoding it here in the SDK will lead to a bad interpretation of the request URL and therefore the lack of the `issuer` query param.

_Note: an alternative solution would be decoding URIs in the API so we could leave this code untouched; however, I believe doing so in the SDK would cause fewer side effects._

### ✅ Fixed Issues

- [x] https://github.com/magiclabs/magic-admin-js/issues/68

### 🚨 Test instructions

https://github.com/magiclabs/magic-admin-js/issues/68

- [x] `patch`: `v1.3.1`
