### PR TITLE
allow getMetadata calls to return social provider

### DIFF
--- a/src/modules/users/index.ts
+++ b/src/modules/users/index.ts
@@ -28,16 +28,18 @@ export class UsersModule extends BaseModule {
   public async getMetadataByIssuer(issuer: string): Promise<MagicUserMetadata> {
     if (!this.sdk.secretApiKey) throw createApiKeyMissingError();
 
-    const data = await get<{ issuer: string | null; public_address: string | null; email: string | null }>(
-      `${this.sdk.apiBaseUrl}/v1/admin/auth/user/get`,
-      this.sdk.secretApiKey,
-      { issuer },
-    );
+    const data = await get<{
+      issuer: string | null;
+      public_address: string | null;
+      email: string | null;
+      oauth_provider: string | null;
+    }>(`${this.sdk.apiBaseUrl}/v1/admin/auth/user/get`, this.sdk.secretApiKey, { issuer });
 
     return {
       issuer: data.issuer ?? null,
       publicAddress: data.public_address ?? null,
       email: data.email ?? null,
+      oauthProvider: data.oauth_provider ?? null,
     };
   }
 

--- a/src/types/sdk-types.ts
+++ b/src/types/sdk-types.ts
@@ -6,4 +6,5 @@ export interface MagicUserMetadata {
   issuer: string | null;
   publicAddress: string | null;
   email: string | null;
+  oauthProvider: string | null;
 }

--- a/test/spec/modules/users/getMetadataByIssuer.spec.ts
+++ b/test/spec/modules/users/getMetadataByIssuer.spec.ts
@@ -23,6 +23,7 @@ test('#01: Successfully GETs to metadata endpoint via issuer', async t => {
     issuer: 'foo',
     publicAddress: 'bar',
     email: 'baz',
+    oauthProvider: null,
   });
 });
 
@@ -41,6 +42,7 @@ test('#02: Successfully GETs `null` metadata endpoint via issuer', async t => {
     issuer: null,
     publicAddress: null,
     email: null,
+    oauthProvider: null,
   });
 });
 

--- a/test/spec/modules/users/getMetadataByIssuer.spec.ts
+++ b/test/spec/modules/users/getMetadataByIssuer.spec.ts
@@ -5,7 +5,7 @@ import { API_KEY } from '../../../lib/constants';
 import { createApiKeyMissingError, MagicAdminSDKError } from '../../../../src/core/sdk-exceptions';
 import { get } from '../../../../src/utils/rest';
 
-const successRes = Promise.resolve({ issuer: 'foo', public_address: 'bar', email: 'baz' });
+const successRes = Promise.resolve({ issuer: 'foo', public_address: 'bar', email: 'baz', oauth_provider: 'foo1' });
 const nullRes = Promise.resolve({});
 
 test('#01: Successfully GETs to metadata endpoint via issuer', async t => {
@@ -23,7 +23,7 @@ test('#01: Successfully GETs to metadata endpoint via issuer', async t => {
     issuer: 'foo',
     publicAddress: 'bar',
     email: 'baz',
-    oauthProvider: null,
+    oauthProvider: 'foo1',
   });
 });
 


### PR DESCRIPTION
### 📦 Pull Request

getMetadata calls will now return the oauth provider if a user went through a social login

### ✅ Fixed Issues

- [List any fixed issues here like: Fixes #XXXX]

### 🚨 Test instructions

[Describe any additional context required to test the PR/feature/bug fix.]

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!

- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
