### PR TITLE
Fix publish stage to allow for npm publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-20.04
-    name: Run style/security checks & tests
+    name: Publish
     container:
       image: node:16-slim
     steps:
@@ -23,6 +23,8 @@ jobs:
           yarn
 
       - name: Publish to NPM
-        run: yarn auto shipit
+        run: |
+          apt-get update && apt-get install -y git
+          yarn auto shipit
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### 📦 Pull Request

This is a follow up for https://github.com/magiclabs/magic-admin-js/pull/93. It fixes an incorrect stage name and ensures that git is included in the publish container, since it is required for `auto` to function properly.

### 🚨 Test instructions

The testing can unfortunately only be viewed post-merge, once the action is triggered. The previous output can be viewed here: https://github.com/magiclabs/magic-admin-js/actions/runs/3519360158/jobs/5899228541