### PR TITLE
Fix publish stage issues with git history

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,12 @@ jobs:
   publish:
     runs-on: ubuntu-20.04
     name: Publish
-    container:
-      image: node:16-slim
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - uses: actions/checkout@v3
+
+      - name: Prepare repository
+        run: git fetch --unshallow --tags
 
       - name: Setup node
         uses: actions/setup-node@v3
@@ -22,9 +24,10 @@ jobs:
           yarn -v
           yarn
 
-      - name: Publish to NPM
-        run: |
-          apt-get update && apt-get install -y git
-          yarn auto shipit
+      - name: Create Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          yarn
+          yarn auto shipit


### PR DESCRIPTION
### 📦 Pull Request

Now, the publish stage will fetch the full git history and tags before installing. This pr also stops using the node container, since it isn't necessary/required. It also updates both the npm and github tokens to use project secrets via the env config.

### 🚨 Test instructions

View the results from when the project is merged. Previous stage can be viewed here: https://github.com/magiclabs/magic-admin-js/actions/runs/3519403917/jobs/5899316449