### PR TITLE
Include dist dir when publishing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,4 +16,4 @@
 - `minor`: New Feature?
 - `major`: Breaking Change?
 - `skip-release`: It's unnecessary to publish this change.
--->åå
+-->

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,8 +26,9 @@ jobs:
 
       - name: Create Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ADMIN_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           yarn
+          yarn build
           yarn auto shipit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,8 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     steps:
       - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.ADMIN_TOKEN }}
 
       - name: Prepare repository
         run: git fetch --unshallow --tags

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Magic Authentication Admin Javascript SDK
 
-[![<MagicHQ>](https://circleci.com/gh/magiclabs/magic-admin-js.svg?style=shield)](https://circleci.com/gh/MagicHQ/magic-admin-js)
-
+[![Publish](https://github.com/magiclabs/magic-admin-js/actions/workflows/publish.yml/badge.svg?branch=master)](https://github.com/magiclabs/magic-admin-js/actions/workflows/publish.yml)
 > The Magic Admin SDK lets developers secure endpoints, manage users, and create middlewares via easy-to-use utilities.
 
 <p align="center">


### PR DESCRIPTION
### 📦 Pull Request

Previously, the publish step didn't create a build in the dist dir, so the assets didn't get included in the published module. This pr includes the build stage, to resolve that issue.

### ✅ Fixed Issues

Fixes https://github.com/magiclabs/magic-admin-js/issues/97
