### PR TITLE
feat: add username data field to metadata call response

### DIFF
--- a/src/modules/users/index.ts
+++ b/src/modules/users/index.ts
@@ -61,6 +61,7 @@ export class UsersModule extends BaseModule {
       email: string | null;
       oauth_provider: string | null;
       phone_number: string | null;
+      username: string | null;
       wallets: MagicWallet[] | null;
     }>(`${this.sdk.apiBaseUrl}/v1/admin/auth/user/get`, this.sdk.secretApiKey, { issuer, wallet_type: walletType });
 
@@ -70,6 +71,7 @@ export class UsersModule extends BaseModule {
       email: data.email ?? null,
       oauthProvider: data.oauth_provider ?? null,
       phoneNumber: data.phone_number ?? null,
+      username: data.username ?? null,
       wallets: data.wallets ?? null,
     };
   }

--- a/src/types/sdk-types.ts
+++ b/src/types/sdk-types.ts
@@ -15,5 +15,6 @@ export interface MagicUserMetadata {
   email: string | null;
   oauthProvider: string | null;
   phoneNumber: string | null;
+  username: string | null;
   wallets: MagicWallet[] | null;
 }

--- a/test/spec/modules/users/getMetadataByIssuer.spec.ts
+++ b/test/spec/modules/users/getMetadataByIssuer.spec.ts
@@ -1,8 +1,8 @@
-import { createMagicAdminSDK } from '../../../lib/factories';
-import { API_KEY } from '../../../lib/constants';
 import { createApiKeyMissingError } from '../../../../src/core/sdk-exceptions';
-import { get } from '../../../../src/utils/rest';
 import { WalletType } from '../../../../src/types/wallet-types';
+import { get } from '../../../../src/utils/rest';
+import { API_KEY } from '../../../lib/constants';
+import { createMagicAdminSDK } from '../../../lib/factories';
 
 const successRes = Promise.resolve({
   issuer: 'foo',
@@ -10,6 +10,7 @@ const successRes = Promise.resolve({
   email: 'baz',
   oauth_provider: 'foo1',
   phone_number: '+1234',
+  username: 'buzz',
 });
 const successResWithWallets = Promise.resolve({
   issuer: 'foo',
@@ -17,13 +18,14 @@ const successResWithWallets = Promise.resolve({
   email: 'baz',
   oauth_provider: 'foo1',
   phone_number: '+1234',
+  username: 'buzz',
   wallets: [
     {
       wallet_type: 'SOLANA',
       network: 'MAINNET',
-      public_address: 'barxyz'
-    }
-  ]
+      public_address: 'barxyz',
+    },
+  ],
 });
 const nullRes = Promise.resolve({});
 
@@ -35,18 +37,22 @@ test('Successfully GETs to metadata endpoint via issuer', async () => {
 
   const result = await sdk.users.getMetadataByIssuer('did:ethr:0x1234');
 
+  console.log(result);
+
   const getArguments = getStub.mock.calls[0];
   expect(getArguments).toEqual([
     'https://example.com/v1/admin/auth/user/get',
     API_KEY,
-    { issuer: 'did:ethr:0x1234', wallet_type: 'NONE'},
+    { issuer: 'did:ethr:0x1234', wallet_type: 'NONE' },
   ]);
+
   expect(result).toEqual({
     issuer: 'foo',
     publicAddress: 'bar',
     email: 'baz',
     oauthProvider: 'foo1',
     phoneNumber: '+1234',
+    username: 'buzz',
     wallets: null,
   });
 });
@@ -71,6 +77,7 @@ test('Successfully GETs `null` metadata endpoint via issuer', async () => {
     email: null,
     oauthProvider: null,
     phoneNumber: null,
+    username: null,
     wallets: null,
   });
 });
@@ -108,10 +115,13 @@ test('Successfully GETs to metadata endpoint via issuer and wallet type', async 
     email: 'baz',
     oauthProvider: 'foo1',
     phoneNumber: '+1234',
-    wallets: [{
-      wallet_type: 'SOLANA',
-      network: 'MAINNET',
-      public_address: 'barxyz'
-    }],
+    username: 'buzz',
+    wallets: [
+      {
+        wallet_type: 'SOLANA',
+        network: 'MAINNET',
+        public_address: 'barxyz',
+      },
+    ],
   });
 });


### PR DESCRIPTION
### 📦 Pull Request

<!-- Provide a general summary of the pull request here. -->

The `username` field was added to the user metadata and now the Admin SDK needs to consume this and return it to the developer.

### ✅ Fixed Issues

<!-- List any fixed issues here like: Fixes #XXXX -->
- [Ticket](https://magiclink.atlassian.net/browse/PDEEXP-856?atlOrigin=eyJpIjoiMWRhNmNlYzU3YzFlNDhhZWFiZTY2NWI4NTZhNWExZDAiLCJwIjoiaiJ9)
  - adds `username` to metadata return value and `MagicUserMetadata` interface
  - adds `username` to tests to `getMetadataByIssuer.spec.ts` 

### 🚨 Test instructions

<!-- Describe any additional context required to test the PR/feature/bug fix. -->

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!
<!--
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
-->