### PR TITLE
fix: use --frozen-lockfile in CI to prevent yarn.lock modifications

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,13 +24,13 @@ jobs:
           cache: 'yarn'
       - run: |
           yarn -v
-          yarn
+          yarn install --frozen-lockfile
 
       - name: Create Release
         env:
           GITHUB_TOKEN: ${{ secrets.ADMIN_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          yarn
+          yarn install --frozen-lockfile
           yarn build
           yarn auto shipit


### PR DESCRIPTION
This prevents the auto shipit command from failing due to uncommitted changes in yarn.lock that occur when yarn install modifies the lock file in CI.

### 📦 Pull Request

<!-- Provide a general summary of the pull request here. -->

### ✅ Fixed Issues

<!-- List any fixed issues here like: Fixes #XXXX -->

### 🚨 Test instructions

<!-- Describe any additional context required to test the PR/feature/bug fix. -->

### ⚠️ Don't forget to add a [semver](https://semver.org/) label!
<!--
- `patch`: Bug Fix?
- `minor`: New Feature?
- `major`: Breaking Change?
- `skip-release`: It's unnecessary to publish this change.
-->
